### PR TITLE
Loosens logic for finding linux-image deb package

### DIFF
--- a/filter_plugins/extract_kernel_version.py
+++ b/filter_plugins/extract_kernel_version.py
@@ -13,7 +13,7 @@ def extract_kernel_version(deb_package):
     # Convert to basename in case the filter call was not prefixed with '|basename'.
     deb_package = os.path.basename(deb_package)
     try:
-        results = re.findall(r'^linux-image-([\d.]+-grsec)', deb_package)[0]
+        results = re.findall(r'^.*-image-([\d.]+-grsec).*$', deb_package)[0]
     except IndexError:
         msg = ("Could not determine desired kernel version in '{}', make sure it matches "
               "the regular expression '^linux-image-[\d.]+-grsec'").format(deb_package)

--- a/tasks/set_host_facts.yml
+++ b/tasks/set_host_facts.yml
@@ -32,7 +32,7 @@
 - name: Inspect deb packages for kernel image package
   set_fact:
     grsecurity_install_kernel_image_package: "{{ item }}"
-  when: (item|basename).startswith('linux-image')
+  when: "'image' in item|basename"
   with_items: "{{ grsecurity_install_combined_deb_packages }}"
 
 - name: Set desired kernel version as host fact.


### PR DESCRIPTION
Rather than expecting the default package stem of "linux-image-*", we'll
simply expect the substring "image" to occur in the package name, and
that'll be enough to infer the desired kernel version. The role will
then support installation of kernel packages that have a custom name,
e.g. "organization-purpose-4.4.x-grsec", rather than the more common
(and usually dist-provided) "linux-image-4.4.x-grsec" pattern.

Closes #2.