### PR TITLE
Ignore Python runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Was getting regular errors about this problem particularly,
`filter_plugins/extract_kernel_version.pyc` showing up as a new file.