### PR TITLE
Fix regex in build with LOCALVERSION

### DIFF
--- a/filter_plugins/extract_kernel_version.py
+++ b/filter_plugins/extract_kernel_version.py
@@ -10,13 +10,16 @@ def extract_kernel_version(deb_package):
     the kernel version it would install, e.g. "4.4.4-grsec".
     """
 
-    # Convert to basename in case the filter call was not prefixed with '|basename'.
+    # Convert to basename in case the filter
+    # call was not prefixed with '|basename'.
     deb_package = os.path.basename(deb_package)
     try:
-        results = re.findall(r'^.*-image-([\d.]+-grsec).*$', deb_package)[0]
+        reg_pattern = "^.*-image-([\d.]+-grsec[A-Za-z0-9\-\.]*)_.*$"
+        results = re.findall(r'{}'.format(reg_pattern), deb_package)[0]
     except IndexError:
-        msg = ("Could not determine desired kernel version in '{}', make sure it matches "
-              "the regular expression '^linux-image-[\d.]+-grsec'").format(deb_package)
+        msg = ("Could not determine desired kernel version in '{}', make sure"
+               " it matches the regular expression '{}'"
+               ).format(deb_package, reg_pattern)
         raise errors.AnsibleFilterError(msg)
 
     return results

--- a/tasks/grub_config.yml
+++ b/tasks/grub_config.yml
@@ -8,7 +8,7 @@
   #   Debian GNU/Linux, with Linux 3.14.54-grsec
   # Example string NOT to match:
   #   Debian GNU/Linux, with Linux 3.14.54-grsec (recovery mode)
-  when: "{{ item.name | match('.*'+grsecurity_install_desired_kernel_version+'$') }}"
+  when: item.name|match('.*'+grsecurity_install_desired_kernel_version+'$')
 
 - name: Update GRUB timeout for easier console recovery and debugging
   become: yes


### PR DESCRIPTION
In a build where `LOCALVERSION` environment variable was passed in, the current filter logic doesnt properly parse out the kernel version accordingly. Ive modified it a bit to look for everything in between the underscores and extract additional necessary version information. For example, take the following filename `linux-image-4.4.115-grsec-digitalocean.201802041022_4.4.115-grsec-digitalocean.201802041022-1_amd64.deb` . 

The current logic would only extract `4.4.115-grsec` where as in the actual grub config it shows up as `4.4.115-grsec-digitalocean.201802041022`

I've confirmed the new regex logic works with the new and old logic. See:

* [original compliant filename pattern match](https://pythex.org/?regex=%5E.*-image-(%5B%5Cd.%5D%2B-grsec%5BA-Za-z0-9%5C-%5C.%5D*).*%24&test_string=linux-image-4.4.113-grsec_4.4.113-grsec-1_amd64.deb&ignorecase=0&multiline=0&dotall=0&verbose=0)
* [new filename pattern match](https://pythex.org/?regex=%5E.*-image-(%5B%5Cd.%5D%2B-grsec%5BA-Za-z0-9%5C-%5C.%5D*)_.*%24&test_string=linux-image-4.4.113-grsec_4.4.113-grsec-1_amd64.deb&ignorecase=0&multiline=0&dotall=0&verbose=0)